### PR TITLE
Update sac to latest version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643395644,
-        "narHash": "sha256-nETvmStCE1PxyQOUlYJX2POgKAJZydy0oqibWPNGAok=",
+        "lastModified": 1738223116,
+        "narHash": "sha256-Igf0oHuV2W8tV2OQqDsm9Fg5ct9rLuBD9h5GPAiq/qc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5b958f0c226edd2a90d1f776cd7db0fdf47276e3",
+        "rev": "c25903f220d0b558887672cc8321dddf91e99f7e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,14 +15,14 @@
       sacVCs = {
         version = "1.3.3";
         vname = "MijasCosta";
-        changes = "1079";
+        changes = "1291";
         rev = "1";
-        commit = "g648dba";
+        commit = "g383e8";
       };
       stdlibVCs = {
         version = "1.3";
-        changes = "152";
-        commit = "gaa99";
+        changes = "250";
+        commit = "g6dd8";
       };
       sac-compiler = pkgs.callPackage ./sac2c { inherit sacVCs sac-stdlib; };
       sac-stdlib = pkgs.callPackage ./stdlib { inherit sacVCs stdlibVCs; };

--- a/sac2c/default.nix
+++ b/sac2c/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   name = "${pname}-${version}-${vname}-${commit}-${rev}";
   src = fetchurl {
     url = "https://gitlab.sac-home.org/sac-group/sac-packages/-/raw/master/packages/weekly/Linux-x86_64/${version}-${changes}-${rev}/basic/${pname}-${version}-${vname}-${changes}-${commit}-omnibus.tar.gz";
-    hash = "sha256-EFcr8PnzYKXFOHnqdAROUsIADh6OQOOKX8uPQ4+lwPQ=";
+    hash = "sha256-S71aHQapqmylD/eUYncrjyoOwF9ZEwl8veYR0mcy02I=";
   };
 
   # standard libxcrypt installs libxcrypt.so.1 by default, but this isn't the form of
@@ -21,8 +21,8 @@ stdenv.mkDerivation rec {
   mylibxcrypt = pkgs.libxcrypt.overrideAttrs (old: {
     version = "4.4.27";
     src = pkgs.fetchurl {
-      url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.27/libxcrypt-4.4.27.tar.xz";
-      sha256 = "500898e80dc0d027ddaadb5637fa2bf1baffb9ccd73cd3ab51d92ef5b8a1f420";
+      url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.38/libxcrypt-4.4.38.tar.xz";
+      sha256 = "sha256-gDBLnDBup5kyfwHZp1Sb2ygxd4kYJjHxtU9FEbQgbdY=";
     };
     preConfigure = ''
       patchShebangs --build configure
@@ -120,6 +120,6 @@ stdenv.mkDerivation rec {
     description = "The compiler (sac2c) of the Single-Assignment C programming language";
     homepage = "http://www.sac-home.org/";
     #changelog = ??
-    license = ../pkg-LICENSE.txt;
+    license = [ ../pkg-LICENSE.txt ];
   };
 }

--- a/stdlib/default.nix
+++ b/stdlib/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   name = "${pname}-${version}-${changes}-${commit}";
   src = fetchurl {
     url = "https://gitlab.sac-home.org/sac-group/sac-packages/-/raw/master/packages/weekly/Linux-x86_64/${sacVersion}/basic/sac-stdlib-${version}-${changes}-${commit}.tar.gz";
-    hash = "sha256-oJ7A1FI9uj+i+fjU5/bDvKvfVhuIudgYK//CK8UYuaQ=";
+    hash = "sha256-isz+GXP1r/18gvclWEZWBCD+se2obkHGvk//l4rfxLM=";
   };
   #We get rid of the versioned path segments as in nix versioning is in the prefix
   installPhase = ''
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "The standard library for the Single-Assignment C programming language";
     homepage = "http://www.sac-home.org/";
-    license = ../pkg-LICENSE.txt;
+    license = [ ../pkg-LICENSE.txt ];
   };
 }


### PR DESCRIPTION
This PR updates sac to the latest version, and also updates `libxcrypt`.